### PR TITLE
lock door & window moving at the end of the wall

### DIFF
--- a/src/editor/editor/objects/TransformControls/Handle.ts
+++ b/src/editor/editor/objects/TransformControls/Handle.ts
@@ -179,20 +179,31 @@ export class Handle extends Graphics {
                     y: this.mouseEndPoint.y - this.mouseStartPoint.y
                 }
                 if (!this.target.xLocked) {
-                    this.target.position.x = viewportX(this.targetStartPoint.x+ delta.x) 
-                    this.target.position.y = viewportY(this.targetStartPoint.y + delta.y)
+                  this.target.position.x = viewportX(this.targetStartPoint.x + delta.x);
+                  this.target.position.y = viewportY(this.targetStartPoint.y + delta.y);
                 } else {
-                    let amount = (delta.x + delta.y)*0.8;
-                    if (this.localCoords.x + amount >= this.target.parent.width - this.target.width) {
-                        this.target.position.x = this.target.parent.width - this.target.width
-                    } else if (this.localCoords.x + amount <=0 ){
-                        this.target.position.x = 0;
-                    } else {
-                        this.target.position.x = this.localCoords.x + amount;
-
-                    }
-                    // this.target.position.x = viewportX(this.targetStartPoint.x) + delta.x;
-
+                  let amount = (delta.x + delta.y) * 0.8;
+        
+                  //start of wall
+                  if (this.localCoords.x + amount <= WALL_THICKNESS * 0.5) {
+                    this.target.position.x = WALL_THICKNESS * 0.5;
+                  }
+                  //end of wall
+                  else if (
+                    this.localCoords.x + amount >=
+                    this.target.parent.length - this.target.width - WALL_THICKNESS * 0.5 //parent wall length
+                  ) {
+                    this.target.position.x =
+                      this.target.parent.length -
+                      this.target.width -
+                      WALL_THICKNESS * 0.5;
+                  }
+                  //meddle of wall
+                  else {
+                    this.target.position.x = this.localCoords.x + amount;
+                  }
+        
+                  // this.target.position.x = viewportX(this.targetStartPoint.x) + delta.x;
                 }
 
                 break;


### PR DESCRIPTION
![image](https://github.com/mehanix/arcada/assets/86634724/35df201e-cc31-44db-8d98-c2623b174e6b)

when moving a door or window it should not be moved outside of the attached wall