### PR TITLE
fix(Handle): import missing WALL_THICKNESS constant

### DIFF
--- a/src/editor/editor/objects/TransformControls/Handle.ts
+++ b/src/editor/editor/objects/TransformControls/Handle.ts
@@ -4,6 +4,7 @@ import { Point } from "../../../../helpers/Point";
 import { viewportX, viewportY } from "../../../../helpers/ViewportCoordinates";
 import { Furniture } from "../Furniture";
 import { TransformLayer } from "./TransformLayer";
+import { WALL_THICKNESS } from "../../constants";
 
 export enum HandleType {
     Horizontal,


### PR DESCRIPTION
Closes #11
Handle.ts references WALL_THICKNESS in its resize-clamping logic (lines ~188+) but never imports it, so the project fails to compile:

  TS2304: Cannot find name 'WALL_THICKNESS'.

The constant is already exported from editor/editor/constants.ts; this only adds the missing import. No behavior change.