### PR TITLE
feat(history): add undo/redo (Ctrl+Z / Ctrl+Y)

### DIFF
--- a/src/editor/editor/Main.ts
+++ b/src/editor/editor/Main.ts
@@ -11,6 +11,7 @@ import { Pointer } from "./Pointer";
 import { Preview } from "./actions/MeasureToolManager";
 import { showNotification } from "@mantine/notifications";
 import { DeviceFloppy } from "tabler-icons-react";
+import { HistoryManager } from "./actions/HistoryManager";
 
 export class Main extends Viewport {
 
@@ -59,6 +60,8 @@ export class Main extends Viewport {
         this.on("pointermove", this.updatePreview)
         this.on("pointerup", this.updateEnd)
 
+        // Records a baseline snapshot and starts capturing changes for undo/redo.
+        HistoryManager.Instance.init();
     }
     private updatePreview(ev: InteractionEvent) {
         this.addWallManager.updatePreview(ev);
@@ -128,4 +131,14 @@ document.onkeydown = (e) => {
             "icon":DeviceFloppy
         })
     }
-};       
+    // Undo: Ctrl+Z
+    if (e.code == "KeyZ" && e.ctrlKey && !e.shiftKey) {
+        e.preventDefault();
+        HistoryManager.Instance.undo();
+    }
+    // Redo: Ctrl+Y or Ctrl+Shift+Z
+    if ((e.code == "KeyY" && e.ctrlKey) || (e.code == "KeyZ" && e.ctrlKey && e.shiftKey)) {
+        e.preventDefault();
+        HistoryManager.Instance.redo();
+    }
+};

--- a/src/editor/editor/actions/HistoryManager.ts
+++ b/src/editor/editor/actions/HistoryManager.ts
@@ -1,4 +1,5 @@
 import { FloorPlan } from "../objects/FloorPlan";
+import { AddWallManager } from "./AddWallManager";
 
 /**
  * Snapshot-based undo/redo for the floor plan.
@@ -52,6 +53,15 @@ export class HistoryManager {
     /** Pushes the current plan onto the undo stack if it changed. */
     public commit() {
         if (this.restoring) {
+            return;
+        }
+        // Don't snapshot mid wall-draw. The wall tool's first click leaves a lone
+        // node (no wall yet) until the next click connects it. Recording that
+        // transient state would make undo step back to the orphan node instead of
+        // removing the wall cleanly. AddWallManager.previousNode is set while a
+        // chain is open and cleared when it ends (double-click) or the tool
+        // changes (resetTools), so the finished chain is captured on that pointerup.
+        if (AddWallManager.Instance.previousNode !== undefined) {
             return;
         }
         let snapshot: string;

--- a/src/editor/editor/actions/HistoryManager.ts
+++ b/src/editor/editor/actions/HistoryManager.ts
@@ -4,15 +4,10 @@ import { AddWallManager } from "./AddWallManager";
 /**
  * Snapshot-based undo/redo for the floor plan.
  *
- * The editor already serializes the whole plan through FloorPlan.save() /
- * FloorPlan.load(). Instead of giving every Action its own undo()/redo() (which
- * needs careful bookkeeping — e.g. restoring the node links a DeleteWallNode
- * removed, see the TODOs in WallNodeSequence), this records a JSON snapshot at
- * the end of each interaction and reloads a previous/next one to undo/redo.
- *
- * Bonus: it also covers moves and rotations, which are applied directly by the
- * transform handles and aren't modeled as Actions, so a command-based history
- * would miss them.
+ * The editor serializes the whole plan through FloorPlan.save() /
+ * FloorPlan.load(). Instead of giving every Action its own undo()/redo(), 
+ * this records a JSON snapshot at the end of each interaction and reloads 
+ * a previous/next one to undo/redo.
  */
 export class HistoryManager {
     private static instance: HistoryManager;
@@ -113,8 +108,6 @@ export class HistoryManager {
         } catch {
             /* malformed snapshot — ignore */
         }
-        // Release the guard after the current tick so the triggering pointerup's
-        // debounced commit doesn't re-record the state we just restored.
         setTimeout(() => {
             this.restoring = false;
         }, 80);

--- a/src/editor/editor/actions/HistoryManager.ts
+++ b/src/editor/editor/actions/HistoryManager.ts
@@ -1,0 +1,112 @@
+import { FloorPlan } from "../objects/FloorPlan";
+
+/**
+ * Snapshot-based undo/redo for the floor plan.
+ *
+ * The editor already serializes the whole plan through FloorPlan.save() /
+ * FloorPlan.load(). Instead of giving every Action its own undo()/redo() (which
+ * needs careful bookkeeping — e.g. restoring the node links a DeleteWallNode
+ * removed, see the TODOs in WallNodeSequence), this records a JSON snapshot at
+ * the end of each interaction and reloads a previous/next one to undo/redo.
+ *
+ * Bonus: it also covers moves and rotations, which are applied directly by the
+ * transform handles and aren't modeled as Actions, so a command-based history
+ * would miss them.
+ */
+export class HistoryManager {
+    private static instance: HistoryManager;
+
+    private undoStack: string[] = [];
+    private redoStack: string[] = [];
+    private restoring = false;
+    private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    private initialized = false;
+    private readonly LIMIT = 120;
+
+    private constructor() { }
+
+    public static get Instance(): HistoryManager {
+        return this.instance || (this.instance = new this());
+    }
+
+    /** Records the baseline snapshot and starts listening for changes. */
+    public init() {
+        if (this.initialized) {
+            return;
+        }
+        this.initialized = true;
+        this.commit(); // baseline = empty (or loaded) plan
+        // A document-level pointerup fires regardless of Pixi event bubbling /
+        // stopPropagation, so it reliably catches the end of every draw, drag,
+        // resize, rotate and delete interaction.
+        document.addEventListener("pointerup", this.onPointerUp);
+    }
+
+    private onPointerUp = () => {
+        if (this.debounceTimer) {
+            clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = setTimeout(() => this.commit(), 300);
+    };
+
+    /** Pushes the current plan onto the undo stack if it changed. */
+    public commit() {
+        if (this.restoring) {
+            return;
+        }
+        let snapshot: string;
+        try {
+            snapshot = FloorPlan.Instance.save();
+        } catch {
+            return;
+        }
+        if (snapshot === this.undoStack[this.undoStack.length - 1]) {
+            return; // nothing changed
+        }
+        this.undoStack.push(snapshot);
+        if (this.undoStack.length > this.LIMIT) {
+            this.undoStack.shift();
+        }
+        this.redoStack = [];
+    }
+
+    public canUndo(): boolean {
+        return this.undoStack.length > 1;
+    }
+
+    public canRedo(): boolean {
+        return this.redoStack.length > 0;
+    }
+
+    public undo() {
+        if (!this.canUndo()) {
+            return;
+        }
+        const current = this.undoStack.pop() as string;
+        this.redoStack.push(current);
+        this.restore(this.undoStack[this.undoStack.length - 1]);
+    }
+
+    public redo() {
+        if (!this.canRedo()) {
+            return;
+        }
+        const snapshot = this.redoStack.pop() as string;
+        this.undoStack.push(snapshot);
+        this.restore(snapshot);
+    }
+
+    private restore(snapshot: string) {
+        this.restoring = true;
+        try {
+            FloorPlan.Instance.load(snapshot);
+        } catch {
+            /* malformed snapshot — ignore */
+        }
+        // Release the guard after the current tick so the triggering pointerup's
+        // debounced commit doesn't re-record the state we just restored.
+        setTimeout(() => {
+            this.restoring = false;
+        }, 80);
+    }
+}

--- a/src/editor/editor/objects/TransformControls/Handle.ts
+++ b/src/editor/editor/objects/TransformControls/Handle.ts
@@ -2,8 +2,10 @@ import { Graphics, InteractionEvent } from "pixi.js";
 import { isMobile } from "react-device-detect";
 import { Point } from "../../../../helpers/Point";
 import { viewportX, viewportY } from "../../../../helpers/ViewportCoordinates";
+import { Wall } from "../Walls/Wall";
 import { Furniture } from "../Furniture";
 import { TransformLayer } from "./TransformLayer";
+import { WALL_THICKNESS } from "../../constants";
 
 export enum HandleType {
     Horizontal,
@@ -191,10 +193,10 @@ export class Handle extends Graphics {
                   //end of wall
                   else if (
                     this.localCoords.x + amount >=
-                    this.target.parent.length - this.target.width - WALL_THICKNESS * 0.5 //parent wall length
+                    (this.target.parent as Wall).length - this.target.width - WALL_THICKNESS * 0.5 //parent wall length
                   ) {
                     this.target.position.x =
-                      this.target.parent.length -
+                      (this.target.parent as Wall).length -
                       this.target.width -
                       WALL_THICKNESS * 0.5;
                   }


### PR DESCRIPTION
The editor pushes actions onto FloorPlan.actions but never undoes them (see the undo-related TODOs in WallNodeSequence/DeleteWallNodeAction). This adds a HistoryManager that records a JSON snapshot of the plan via the existing FloorPlan.save() at the end of each interaction and reloads a previous/next snapshot to undo/redo.

- HistoryManager (singleton, in the style of AddWallManager): undo/redo stacks, debounced capture on a document 'pointerup' (fires regardless of Pixi event bubbling), anti-reentrancy guard while restoring.
- Main: HistoryManager.Instance.init() at the end of setup(); Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y added to the existing document.onkeydown handler.
- Public canUndo()/canRedo()/undo()/redo() so toolbar buttons can be wired too.